### PR TITLE
fix(tmux): tmux_attachをexecutable_taにリネームしコマンドの修正

### DIFF
--- a/dot_config/zsh/functions/executable_ta.zsh
+++ b/dot_config/zsh/functions/executable_ta.zsh
@@ -3,7 +3,7 @@ ta() {
 
     if [[ -n ${name} ]]; then
         # NOTE: 命名の表記揺れを吸収するため｡ある程度置換する｡
-        # zsh 機能で大文字化 
+        # zsh 機能で大文字化
         name=${(U)name}
         # セッション名の簡易正規化(英数._- 以外は - に変換)
         name=${name//[^A-Za-z0-9_.-]/-}
@@ -23,7 +23,7 @@ ta() {
             # 直前のセッションへ（なければ何もしない）
             tmux switch-client -l 2>/dev/null || tmux display-message "no previous session"
         else
-            exec tmux atache-session 2>/dev/null || exec tmux new-session
+            tmux atache-session 2>/dev/null || tmux new-session
         fi
     fi
 }


### PR DESCRIPTION
- 不要なスペースを削除
- exec は特に使う理由はなかったので削除