### PR TITLE
feat: voiceEnabled 有効化と conform.nvim への prettierd 設定追加

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -2,6 +2,7 @@
     "$schema": "https://json.schemastore.org/claude-code-settings.json",
     "language": "japanese",
     "vim": true,
+    "voiceEnabled": true,
     "enabledPlugins": {
         "lua-lsp@claude-plugins-official": true,
         "gopls-lsp@claude-plugins-official": true

--- a/dot_config/nvim/lua/plugins/formatting.lua
+++ b/dot_config/nvim/lua/plugins/formatting.lua
@@ -1,31 +1,31 @@
 return {
-    {
-        "stevearc/conform.nvim",
-        opts = {
-            formatters_by_ft = {
-                lua = { "stylua" },
-                go = { "golangci-lint", "goimports", "gofmt" },
-            },
-            default_format_opts = {
-                lsp_format = "fallback",
-            },
-            format_on_save = {
-                lsp_format = "fallback",
-                timeout_ms = 500,
-            },
-        },
+	{
+		"stevearc/conform.nvim",
+		opts = {
+			formatters_by_ft = {
+				lua = { "stylua" },
+				go = { "golangci-lint", "goimports", "gofmt" },
+			},
+			default_format_opts = {
+				lsp_format = "fallback",
+			},
+			format_on_save = {
+				lsp_format = "fallback",
+				timeout_ms = 500,
+			},
+		},
 
-        init = function()
-            vim.o.formatexpr = "v:lua.require'conform'.formatexpr()"
-        end,
+		init = function()
+			vim.o.formatexpr = "v:lua.require'conform'.formatexpr()"
+		end,
 
-        config = function()
-            vim.keymap.set("n", "<leader>f", function()
-                require("conform").format({
-                    lsp_format = "fallback",
-                    timeout_ms = 500,
-                })
-            end, { desc = "Format buffer (conform.nvim)" })
-        end,
-    },
+		config = function()
+			vim.keymap.set("n", "<leader>f", function()
+				require("conform").format({
+					lsp_format = "fallback",
+					timeout_ms = 500,
+				})
+			end, { desc = "Format buffer (conform.nvim)" })
+		end,
+	},
 }

--- a/dot_config/nvim/lua/plugins/formatting.lua
+++ b/dot_config/nvim/lua/plugins/formatting.lua
@@ -5,6 +5,7 @@ return {
 			formatters_by_ft = {
 				lua = { "stylua" },
 				go = { "golangci-lint", "goimports", "gofmt" },
+				markdown = { "prettierd" },
 			},
 			default_format_opts = {
 				lsp_format = "fallback",
@@ -19,7 +20,9 @@ return {
 			vim.o.formatexpr = "v:lua.require'conform'.formatexpr()"
 		end,
 
-		config = function()
+		config = function(_, opts)
+			require("conform").setup(opts)
+
 			vim.keymap.set("n", "<leader>f", function()
 				require("conform").format({
 					lsp_format = "fallback",

--- a/dot_config/nvim/lua/plugins/lsp.lua
+++ b/dot_config/nvim/lua/plugins/lsp.lua
@@ -10,6 +10,7 @@ local lsp_servers = {
 local formatters = {
     "stylua",
     "shfmt",
+    "prettierd",
 }
 local go_tools = {
     -- NOTE: gopher.nvim で使用


### PR DESCRIPTION
## 変更内容

- Claude Code の `voiceEnabled` を有効化
- `conform.nvim` の `config` 関数で `setup(opts)` を呼び出すよう修正
- conform.nvim と LSP に `prettierd` を追加（Markdown フォーマット対応）
- `formatting.lua` のインデントをタブに統一

## 変更の理由

- `voiceEnabled` で Claude の音声機能を有効化
- `conform.nvim` が opts を正しく受け取れていなかったため `setup(opts)` 呼び出しを追加
- Markdown ファイルも自動フォーマットできるよう `prettierd` を追加

## テスト

- [x] 動作確認済み

🤖 Generated with [Claude Code](https://claude.ai/claude-code)