### PR TITLE
feat: 自動保存・フォーマット設定改善と Claude Code パーミッション追加

### DIFF
--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -3,6 +3,7 @@
     "language": "japanese",
     "vim": true,
     "voiceEnabled": true,
+    "effortLevel": "high",
     "enabledPlugins": {
         "lua-lsp@claude-plugins-official": true,
         "gopls-lsp@claude-plugins-official": true,
@@ -61,6 +62,12 @@
             "Bash(git merge:*)",
             "Bash(git rebase:*)"
         ]
+    },
+    "env": {
+        "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1",
+        "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
+        "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1",
+        "CLAUDE_CODE_SUBAGENT_MODEL": "sonnet"
     },
     "hooks": {
         "Stop": [

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -35,7 +35,12 @@
             "Bash(gh run list:*)",
             "Bash(gh api:*)",
             "Bash(gh search:*)",
-            "Bash(go test*)"
+            "Bash(go test*)",
+            "Bash(git status:*)",
+            "Bash(git diff:*)",
+            "Bash(git log:*)",
+            "Bash(git branch:*)",
+            "Bash(git show:*)"
             {{- if hasKey . "claudeAllowDomains" }}
             {{- range .claudeAllowDomains }},
             "Bash(curl:{{ . }})"

--- a/dot_config/nvim/lua/options.lua
+++ b/dot_config/nvim/lua/options.lua
@@ -1,4 +1,3 @@
--- 行番号を表示
 vim.o.number = true
 
 -- マウスモードを有効化
@@ -68,6 +67,13 @@ vim.o.tabstop = 4
 vim.o.shiftwidth = 4
 -- 挿入・削除時の幅
 vim.o.softtabstop = 4
+
+-- Neovim内のバッファ切り替え時に保存
+vim.o.autowriteall = true
+vim.api.nvim_create_autocmd({ "BufLeave", "FocusLost" }, {
+	pattern = "*",
+	command = "silent! wall",
+})
 
 -- diagnostic
 vim.diagnostic.config({

--- a/dot_config/nvim/lua/plugins/editor.lua
+++ b/dot_config/nvim/lua/plugins/editor.lua
@@ -234,6 +234,7 @@ return {
 		opts = {
 			-- 5分たったバッファを自動的に閉じる
 			retirementAgeMins = 5,
+			minimumBufferNum = 5,
 		},
 	},
 }

--- a/dot_config/nvim/lua/plugins/formatting.lua
+++ b/dot_config/nvim/lua/plugins/formatting.lua
@@ -10,10 +10,6 @@ return {
 			default_format_opts = {
 				lsp_format = "fallback",
 			},
-			format_on_save = {
-				lsp_format = "fallback",
-				timeout_ms = 500,
-			},
 		},
 
 		init = function()
@@ -22,6 +18,13 @@ return {
 
 		config = function(_, opts)
 			require("conform").setup(opts)
+
+			vim.api.nvim_create_autocmd({ "BufWritePre", "BufLeave", "FocusLost" }, {
+				pattern = "*",
+				callback = function(args)
+					require("conform").format({ bufnr = args.buf })
+				end,
+			})
 
 			vim.keymap.set("n", "<leader>f", function()
 				require("conform").format({


### PR DESCRIPTION
## 変更内容

- `autowriteall` を有効化し、`BufLeave` / `FocusLost` で `:wall` を実行する自動保存を追加
- conform.nvim の `format_on_save` オプションを削除し、`BufWritePre` autocmd で明示的にフォーマットを呼び出すよう変更
- バッファ自動退避（retire.nvim）の `minimumBufferNum` を 5 に設定
- Claude Code の permissions allow に読み取り専用 git コマンドを追加（`git status` / `diff` / `log` / `branch` / `show`）

## 変更の理由

`format_on_save` オプションは `:wall` 経由の保存でフォーマットが実行されない問題があった。
`BufWritePre` autocmd で明示的に呼び出すことで、自動保存時にもフォーマットが確実に動作するようにする。

読み取り専用の git コマンドは副作用がないため、毎回確認を求める必要がなく allow リストに追加した。

## テスト

- [x] 動作確認済み

🤖 Generated with [Claude Code](https://claude.ai/claude-code)