### PR TITLE
feat: rtk 導入・Neovim プラグイン更新・main push 保護

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -3,6 +3,7 @@ cask "font-hackgen-nerd"
 cask "font-moralerspace"
 
 # cli
+brew "git"
 brew "tmux"
 brew "mise"
 brew "bat"

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -42,7 +42,8 @@
             "Bash(git diff:*)",
             "Bash(git log:*)",
             "Bash(git branch:*)",
-            "Bash(git show:*)"
+            "Bash(git show:*)",
+            "Bash(rtk:*)"
         ],
         "deny": [
             "Read(./.env)",

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -7,16 +7,7 @@
     "enabledPlugins": {
         "lua-lsp@claude-plugins-official": true,
         "gopls-lsp@claude-plugins-official": true,
-        "pyright-lsp@claude-plugins-official": true,
-        "example-skills@anthropic-agent-skills": true
-    },
-    "extraKnownMarketplaces": {
-        "anthropic-agent-skills": {
-            "source": {
-                "source": "github",
-                "repo": "anthropics/skills"
-            }
-        }
+        "pyright-lsp@claude-plugins-official": true
     },
     "statusLine": {
         "type": "command",

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -43,11 +43,6 @@
             "Bash(git log:*)",
             "Bash(git branch:*)",
             "Bash(git show:*)"
-            {{- if hasKey . "claudeAllowDomains" }}
-            {{- range .claudeAllowDomains }},
-            "Bash(curl:{{ . }})"
-            {{- end }}
-            {{- end }}
         ],
         "deny": [
             "Read(./.env)",
@@ -89,6 +84,17 @@
                     {
                         "type": "command",
                         "command": "~/.local/bin/claude-notify '入力待ちです'"
+                    }
+                ]
+            }
+        ],
+        "PreToolUse": [
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "rtk hook claude"
                     }
                 ]
             }

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -69,17 +69,6 @@
                 ]
             }
         ],
-        "Notification": [
-            {
-                "matcher": "",
-                "hooks": [
-                    {
-                        "type": "command",
-                        "command": "~/.local/bin/claude-notify '入力待ちです'"
-                    }
-                ]
-            }
-        ],
         "PreToolUse": [
             {
                 "matcher": "Bash",

--- a/dot_config/git/config
+++ b/dot_config/git/config
@@ -19,3 +19,7 @@
         tool = codediff
 [mergetool "codediff"]
         cmd = nvim "$MERGED" -c "CodeDiff merge \"$MERGED\""
+
+[hook "no-push-main"]
+    event = pre-push
+    command = ~/.local/bin/git-no-push-main

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -29,6 +29,7 @@ node = "latest"
 
 # For Rust
 rust = "latest"
+"github:rtk-ai/rtk" = "latest"
 
 # For Lua
 "cargo:selene" = "latest"

--- a/dot_config/nvim/plugin/20_editor.lua
+++ b/dot_config/nvim/plugin/20_editor.lua
@@ -148,13 +148,13 @@ require("codediff").setup({
 -- カーソル移動強化
 --
 vim.pack.add({
-    { src = "https://codeberg.org/andyg/leap.nvim" },
+    { src = "https://github.com/nvim-mini/mini.jump2d" },
 })
-
-require("leap").setup({})
-
-vim.keymap.set({ "n", "x", "o" }, "s", "<Plug>(leap)")
-vim.keymap.set("n", "S", "<Plug>(leap-from-window)")
+require("mini.jump2d").setup({
+    mappings = {
+        start_jumping = "s",
+    },
+})
 
 --
 -- ウィンドウ管理

--- a/dot_config/nvim/plugin/20_editor.lua
+++ b/dot_config/nvim/plugin/20_editor.lua
@@ -132,6 +132,7 @@ require('blink.indent').setup({})
 vim.pack.add({
     { src = "https://github.com/lewis6991/gitsigns.nvim" },
     { src = "https://github.com/esmuellert/codediff.nvim" },
+    { src = "https://github.com/linrongbin16/gitlinker.nvim" }
 })
 
 require('gitsigns').setup()
@@ -143,6 +144,7 @@ require("codediff").setup({
         discard_hunk = "<leader>hr",
     }
 })
+require('gitlinker').setup()
 
 --
 -- カーソル移動強化

--- a/dot_config/nvim/plugin/50_coding.lua
+++ b/dot_config/nvim/plugin/50_coding.lua
@@ -69,7 +69,7 @@ end, { desc = "Format buffer (conform.nvim)" })
 -- リンター
 --
 vim.pack.add({
-    { src = "ussenegger/nvim-lint" },
+    { src = "https://github.com/mfussenegger/nvim-lint" },
 })
 
 local lint         = require("lint")

--- a/dot_local/bin/executable_git-no-push-main
+++ b/dot_local/bin/executable_git-no-push-main
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
+    if [[ "$remote_ref" =~ ^refs/heads/(main|master)$ ]]; then
+        echo "error: push to '$remote_ref' is not allowed" >&2
+        exit 1
+    fi
+done
+exit 0

--- a/mise.toml
+++ b/mise.toml
@@ -46,5 +46,18 @@ run = [
     "mise upgrade"
 ]
 
-[tools]
-ghq = "latest"
+[tasks."skill:install"]
+description = "スキルのインストール"
+run = """
+for agent in github-copilot claude-code codex gemini-cli; do
+    gh skill install anthropics/skills skill-creator --scope user --agent $agent
+    gh skill install heptameta/heptabase-cli-skills heptabase-cli --scope user --agent $agent
+done
+"""
+
+[tasks."skill:update"]
+description = "スキルの更新"
+run = [
+    "gh skill update",
+]
+


### PR DESCRIPTION
## 変更内容

- `rtk` ツールを mise に追加し、Claude Code のフック・許可設定を整備する
- `settings.json` をテンプレートから通常ファイルに変換し、rtk フック（PreToolUse）を追加する
- `anthropic-agent-skills` マーケットプレイス設定を削除し、`mise run skill:install` / `mise run skill:update` タスクで管理する方式に移行する
- `Notification` フックを削除する
- nvim-lint の `src` を完全な GitHub URL に修正する
- leap.nvim を mini.jump2d に置き換える（`s` キーで起動）
- gitlinker.nvim を追加する
- Git 2.54 の config-based hooks を使って main/master ブランチへの push を防止する

## 変更の理由

rtk をトークン削減 CLI として導入し、Claude Code がコマンド実行時に自動的に rtk 経由でフィルタリングされるよう設定する。スキルの管理も mise タスクに統一して一元管理できるようにする。不要になった Notification フックも合わせて削除する。カーソルジャンプを leap.nvim から mini.jump2d に移行する。gitlinker.nvim を追加して Git 行リンクのコピーを可能にする。Homebrew の git 2.54 を導入し、設定ファイルベースの pre-push フックで誤って main に push するのを防ぐ。

## テスト

- [x] `rtk --version` でバージョン確認
- [x] Claude Code 上でコマンド実行時に rtk フックが動作することを確認
- [x] `mise run skill:install` でスキルがインストールされることを確認
- [x] Neovim で `s` キーで mini.jump2d が起動することを確認
- [x] gitlinker.nvim でファイルの Git リンクがコピーできることを確認
- [x] `git push origin main` を試みてエラーで止まることを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)