### PR TITLE
chore: エディタ環境・ツール管理設定を更新する

### DIFF
--- a/.chezmoiexternal.toml
+++ b/.chezmoiexternal.toml
@@ -10,11 +10,11 @@
     type = "git-repo"
     url = "https://github.com/tmux-plugins/tmux-cpu.git"
     refreshPeriod = "168h"
-[".config/tmux/plugins/tmux-plugins/tmux-battery"]
-    type = "git-repo"
-    url = "https://github.com/tmux-plugins/tmux-battery.git"
-    refreshPeriod = "168h"
 [".config/tmux/plugins/tmux-plugins/tmux-fzf"]
     type = "git-repo"
     url = "https://github.com/sainnhe/tmux-fzf.git"
+    refreshPeriod = "168h"
+[".config/tmux/plugins/eduwass/tmux-palette"]
+    type = "git-repo"
+    url = "https://github.com/eduwass/tmux-palette.git"
     refreshPeriod = "168h"

--- a/Brewfile
+++ b/Brewfile
@@ -39,6 +39,7 @@ brew "mas"
 
 # vscode
 vscode "MS-CEINTL.vscode-language-pack-ja"
+vscode "vscodevim.vim"
 
 # for app store
 mas "LINE", id: 539883307

--- a/Brewfile
+++ b/Brewfile
@@ -29,6 +29,7 @@ cask "karabiner-elements"
 cask "raycast"
 cask "kobo"
 cask "chatgpt"
+cask "claude"
 
 # terminal
 brew "starship"

--- a/Brewfile
+++ b/Brewfile
@@ -28,7 +28,6 @@ cask "docker-desktop"
 cask "karabiner-elements"
 cask "raycast"
 cask "kobo"
-cask "claude"
 cask "chatgpt"
 
 # terminal

--- a/dot_claude/skills/pr/SKILL.md
+++ b/dot_claude/skills/pr/SKILL.md
@@ -52,13 +52,14 @@ allowed-tools: Bash(git status), Bash(git log*), Bash(git diff*), Bash(git branc
 5. `gh pr create` コマンドで PR を作成する
    - タイトルは後述のルールに従って生成する
    - 本文は HEREDOC を使って渡す
+   - `--draft` フラグを付けてドラフト PR として作成する
 
 ### テンプレートがある場合
 
 テンプレートの内容に従って各セクションを埋める:
 
 ```bash
-gh pr create --title "タイトル" --body "$(cat <<'EOF'
+gh pr create --draft --title "タイトル" --body "$(cat <<'EOF'
 <!-- テンプレートの内容に従って記載 -->
 EOF
 )"
@@ -67,7 +68,7 @@ EOF
 ### テンプレートがない場合（デフォルトフォーマット）
 
 ```bash
-gh pr create --title "タイトル" --body "$(cat <<'EOF'
+gh pr create --draft --title "タイトル" --body "$(cat <<'EOF'
 ## 変更内容
 
 - 変更点1
@@ -186,5 +187,6 @@ EOF
 
 - PR のベースブランチはリポジトリのデフォルトブランチ（通常 `main` または `master`）を使用する
 - コミット履歴から変更の全体像を把握した上で PR タイトル・本文を作成・更新する
+- PR はドラフトとして作成する（`--draft` フラグを使用）
 - push は明示的に依頼がない限り確認してから実施する
 - `--force` push は使わない

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -12,6 +12,7 @@ awscli = "latest"
 gcloud = "latest"
 act = "latest"
 claude = "latest"
+bun = "latest"
 
 # For Go
 go = "latest"

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -18,6 +18,7 @@ bun = "latest"
 go = "latest"
 "go:github.com/go-delve/delve/cmd/dlv" = { version = "latest" }
 "github:k1LoW/roots" = "latest"
+"github:d-kuro/gwq" = "latest"
 
 
 # For Node.js

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -11,6 +11,7 @@ gh = "latest" # GitHub CLI
 awscli = "latest"
 gcloud = "latest"
 act = "latest"
+claude = "latest"
 
 # For Go
 go = "latest"

--- a/dot_config/nvim/plugin/20_editor.lua
+++ b/dot_config/nvim/plugin/20_editor.lua
@@ -13,8 +13,6 @@ vim.g.canola = {
     },
     columns = canola_columns.detail,
     keymaps = {
-        h = { callback = "actions.parent", mode = "n" },
-        l = { callback = "actions.select", mode = "n" },
         ["gd"] = {
             desc = "Toggle file detail view",
             callback = function()

--- a/dot_config/nvim/plugin/60_ui.lua
+++ b/dot_config/nvim/plugin/60_ui.lua
@@ -135,24 +135,6 @@ require("lspsaga").setup({
     },
 })
 
---
--- Markdown レンダリング
---
-vim.pack.add({
-    { src = "https://github.com/MeanderingProgrammer/render-markdown.nvim" },
-})
-require("render-markdown").setup({
-    file_types = { "markdown" },
-    heading = { position = "inline" },
-    code = {
-        sign = false,
-        border = "thick",
-    },
-    pipe_table = {
-        enabled = false,
-    },
-})
-
 local p = (require("kanagawa-paper.colors").setup() or {}).palette or {}
 
 --

--- a/dot_config/tmux-palette/theme.json
+++ b/dot_config/tmux-palette/theme.json
@@ -1,0 +1,3 @@
+{
+    "name": "github-dark"
+}

--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -110,6 +110,10 @@ set-option -g status-right ""
 set-option -ag status-right "#[fg=#eba0ac]#[fg=#11111b,bg=#eba0ac] #[fg=#cdd6f4,bg=#313244] #(#{@starship_cmd} git_branch) #[fg=#313244]"
 set-option -ag status-right "#[fg=#94e2d5]#[fg=#11111b,bg=#94e2d5]󱃾 #[fg=#cdd6f4,bg=#313244] #(#{@starship_cmd} kubernetes) #[fg=#313244]"
 
+# ウィンドウ名を git リポジトリ名（非 git はディレクトリ名）に自動設定
+set-option -wg automatic-rename on
+set-option -wg automatic-rename-format "#(~/.local/bin/tmux-window-name #{pane_current_path})"
+
 #
 # plugins
 #

--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -157,15 +157,5 @@ set -g @smart-splits_resize_right_key 'M-l' #  --"--
 
 set -g @smart-splits_resize_step_size '3' # change the step-size for resizing.
 
-# Load tmux-fzf
-run ~/.config/tmux/plugins/tmux-plugins/tmux-fzf/main.tmux
-set -g @plugin 'sainnhe/tmux-fzf'
-
-TMUX_FZF_LAUNCH_KEY="f"
-TMUX_FZF_ORDER="session|window|pane"
-TMUX_FZF_SWITCH_CURRENT=1
-
-bind-key -T prefix s run-shell -b \
-  "~/.config/tmux/plugins/tmux-plugins/tmux-fzf/scripts/session.sh switch"
-bind-key -T prefix w run-shell -b \
-  "$HOME/.config/tmux/plugins/tmux-plugins/tmux-fzf/scripts/window.sh switch"
+# Load tmux-palette
+bind-key Space run-shell "~/.config/tmux/plugins/eduwass/tmux-palette/bin/tmux-palette.sh"

--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -158,4 +158,5 @@ set -g @smart-splits_resize_right_key 'M-l' #  --"--
 set -g @smart-splits_resize_step_size '3' # change the step-size for resizing.
 
 # Load tmux-palette
-bind-key Space run-shell "~/.config/tmux/plugins/eduwass/tmux-palette/bin/tmux-palette.sh"
+set -g @palette-key 'off'
+bind-key f run-shell "~/.config/tmux/plugins/eduwass/tmux-palette/bin/tmux-palette.sh"

--- a/dot_config/zed/keymap.json
+++ b/dot_config/zed/keymap.json
@@ -6,14 +6,15 @@
             "shift-l": "vim::EndOfLine",
             "j": "vim::Down",
             "k": "vim::Up",
-            ";": "command_palette::Toggle",
-            ":": "vim::RepeatFind"
+            ":": "command_palette::Toggle"
         }
     },
     {
         "context": "vim_mode == normal && !menu",
         "bindings": {
-            "ctrl-p": "file_finder::Toggle"
+            "ctrl-p": "file_finder::Toggle",
+            ";": "vim::CountCommand",
+            "g q": "editor::Format"
         }
     }
 ]

--- a/dot_config/zed/private_settings.json
+++ b/dot_config/zed/private_settings.json
@@ -2,7 +2,7 @@
     "session": {
         "trust_all_worktrees": true
     },
-    "buffer_font_family": "HackGen35",
+    "buffer_font_family": "Moralerspace Neo",
     "vim_mode": true,
     "ui_font_size": 16,
     "buffer_font_size": 15,

--- a/dot_config/zsh/dot_zshrc
+++ b/dot_config/zsh/dot_zshrc
@@ -164,3 +164,6 @@ alias "vim"="nvim"
 
 # Custom
 alias "c"="clear"
+
+# gwq
+source <(gwq completion zsh)

--- a/dot_config/zsh/functions/executable_fghq.zsh
+++ b/dot_config/zsh/functions/executable_fghq.zsh
@@ -1,7 +1,7 @@
 fghq() {
     local selected_dir 
     selected_dir=$(
-        ghq list -p | roots | fzf \
+        ghq list -p | fzf \
             --query="${LBUFFER}" \
     ) || true
 

--- a/dot_config/zsh/functions/executable_tmux_pane_title.zsh
+++ b/dot_config/zsh/functions/executable_tmux_pane_title.zsh
@@ -1,0 +1,5 @@
+function _set_tmux_pane_title() {
+  [[ -z "$TMUX" ]] && return
+  tmux select-pane -T "$(~/.local/bin/tmux-window-name "$PWD")" 2>/dev/null
+}
+precmd_functions+=(_set_tmux_pane_title)

--- a/dot_local/bin/executable_tmux-window-name
+++ b/dot_local/bin/executable_tmux-window-name
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+dir=${1:-$(pwd)}
+if git -C "$dir" rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+    basename "$(git -C "$dir" rev-parse --show-toplevel)"
+else
+    basename "$dir"
+fi

--- a/private_Library/private_Application Support/private_Code/User/settings.json
+++ b/private_Library/private_Application Support/private_Code/User/settings.json
@@ -3,8 +3,8 @@
     "workbench.activityBar.location": "top",
     "workbench.tree.indent": 20,
     // Font
-    "editor.fontFamily": "HackGen35",
-    "terminal.integrated.fontFamily": "HackGen Console NF",
+    "editor.fontFamily": "Moralerspace Neon",
+    "terminal.integrated.fontFamily": "Moralerspace Neon",
     // Github Copilot
     "github.copilot.nextEditSuggestions.enabled": true,
     // Editor


### PR DESCRIPTION
## 変更内容

- `render-markdown.nvim` プラグインを Neovim から削除する
- canola の `h`/`l` キーバインドを削除する
- Zed の vim キーバインドを VSCode 準拠に統一する（`;` を `CountCommand` へ移動）
- エディタフォントを HackGen35 から Moralerspace に変更する（Zed・VSCode）
- Claude アプリを Homebrew cask から mise 管理に移行する
- VSCodeVim 拡張機能を Brewfile に追加する

## 変更の理由

不要プラグインの整理・キーバインドの統一・フォント変更・ツール管理の一元化を行う。
mise で管理できるツールは Homebrew cask から移行し、環境管理をシンプルにする。

## テスト

- [ ] 動作確認済み

🤖 Generated with [Claude Code](https://claude.ai/claude-code)