### PR TITLE
chore: nvim/mise/claude の設定を整備する

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -7,3 +7,7 @@ Brewfile
 mise.toml
 selene.toml
 dot_config/nvim
+{{ if ne .chezmoi.hostname "0ta2" }}
+.claude/skills
+{{ end }}
+

--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md
 
+@RTK.md
+
 Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
 
 **Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -52,11 +52,6 @@
             "Bash(git rebase:*)"
         ]
     },
-    "env": {
-        "CLAUDE_CODE_DISABLE_1M_CONTEXT": "1",
-        "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
-        "CLAUDE_CODE_SUBAGENT_MODEL": "sonnet"
-    },
     "hooks": {
         "Stop": [
             {

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -7,7 +7,8 @@
     "enabledPlugins": {
         "lua-lsp@claude-plugins-official": true,
         "gopls-lsp@claude-plugins-official": true,
-        "pyright-lsp@claude-plugins-official": true
+        "pyright-lsp@claude-plugins-official": true,
+        "superpowers@claude-plugins-official": true
     },
     "statusLine": {
         "type": "command",

--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -28,7 +28,6 @@ node = "latest"
 "npm:@anthropic-ai/claude-code" = "latest"
 "npm:@zed-industries/claude-code-acp" = "latest"
 "npm:ccusage" = "latest"
-"npm:tree-sitter-cli" = "latest"
 "npm:@fsouza/prettierd" = "latest"
 
 # For Rust
@@ -37,6 +36,7 @@ rust = "latest"
 
 # For Lua
 "cargo:selene" = "latest"
+"cargo:tree-sitter-cli" = "latest"
 
 # For Python
 python = "latest"

--- a/dot_config/nvim/plugin/99_dev.lua
+++ b/dot_config/nvim/plugin/99_dev.lua
@@ -15,18 +15,20 @@ vim.keymap.set("n", "<Leader>k", function()
     require("iwano").toggle("lazygit")
 end)
 
-vim.pack.add({
-    { src = "https://github.com/0ta2/amanoukihashi.nvim", branch = "feat/phase0" },
-})
-
+if vim.loop.os_get_passwd().username == "0ta2" then
+    vim.cmd.packadd("amanoukihashi.nvim-local")
+else
+    vim.pack.add({
+        { src = "https://github.com/0ta2/amanoukihashi.nvim", version = "feat/phase0" },
+    })
+end
 require("amanoukihashi").setup({
     default_cmd = { "claude" },
+    layout = "split",
 })
-
 vim.keymap.set({ "n", "t" }, "<leader>ca", function()
     require("amanoukihashi").toggle("main")
 end, { desc = "Claude Code: main セッション" })
-
 vim.keymap.set({ "n", "t" }, "<leader>cb", function()
     require("amanoukihashi").toggle("feat")
 end, { desc = "Claude Code: feat セッション" })

--- a/dot_config/nvim/plugin/99_dev.lua
+++ b/dot_config/nvim/plugin/99_dev.lua
@@ -14,3 +14,19 @@ require("iwano").setup({
 vim.keymap.set("n", "<Leader>k", function()
     require("iwano").toggle("lazygit")
 end)
+
+vim.pack.add({
+    { src = "https://github.com/0ta2/amanoukihashi.nvim", branch = "feat/phase0" },
+})
+
+require("amanoukihashi").setup({
+    default_cmd = { "claude" },
+})
+
+vim.keymap.set({ "n", "t" }, "<leader>ca", function()
+    require("amanoukihashi").toggle("main")
+end, { desc = "Claude Code: main セッション" })
+
+vim.keymap.set({ "n", "t" }, "<leader>cb", function()
+    require("amanoukihashi").toggle("feat")
+end, { desc = "Claude Code: feat セッション" })

--- a/dot_config/zsh/dot_zshrc
+++ b/dot_config/zsh/dot_zshrc
@@ -152,7 +152,7 @@ export EDITOR="nvim"
 
 # tmux
 if [[ -n "${TMUX}" ]]; then
-    export FZF_DEFAULT_OPTS="--tmux"
+    export FZF_DEFAULT_OPTS="--tmux center,80%,70%"
 fi
 
 # GNU


### PR DESCRIPTION
## 変更内容

- `amanoukihashi.nvim` の設定を `80_ai.lua` から `99_dev.lua` へ移動
- ユーザー名判定（0ta2）でローカルパッケージとリモートリポジトリを切り替え
- `layout = "split"` を設定してデフォルトレイアウトを指定
- `FZF_DEFAULT_OPTS` の `--tmux` オプションに `center,80%,70%` を追加してウィンドウサイズを明示
- `tree-sitter-cli` を npm から cargo に変更
- `RTK.md` 参照を `CLAUDE.md` に追加、非0ta2端末では `.claude/skills` を chezmoi 管理から除外
- `superpowers@claude-plugins-official` プラグインを有効化
- Claude Code の環境変数設定（`CLAUDE_CODE_DISABLE_1M_CONTEXT` 等）を削除

## 変更の理由

- `amanoukihashi.nvim` はローカル開発中のプラグインのため、開発者本人の環境ではローカルパッケージを使用し、他環境ではリモートから取得する構成にした
- fzf の tmux ポップアップウィンドウのサイズが画面全体を覆うため、適切なサイズを指定した
- `tree-sitter-cli` は cargo 経由の方が管理が一貫するため移行した
- `skills` は個人環境固有のため他端末には不要
- superpowers プラグインを導入してスキル機能を利用できるようにした
- 不要になった Claude Code の環境変数設定を整理した

## テスト

- [ ] Neovim で amanoukihashi が正常に起動することを確認
- [ ] fzf の tmux ポップアップが指定サイズで表示されることを確認
- [ ] `tree-sitter-cli` が cargo 経由で利用できることを確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)