### PR TITLE
feat(nvim): amanoukihashi.nvim を統合し sidekick.nvim から移行する

### DIFF
--- a/.chezmoiscripts/run_onchange_01_brew-bundle.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_01_brew-bundle.sh.tmpl
@@ -13,7 +13,7 @@ BREWFILE=${HOME}/Brewfile
 
 if [[ -f "$BREWFILE" ]]; then
     echo "🍺 Brewfile has changed, running brew bundle..."
-    brew bundle --cleanup --file="$BREWFILE"
+    brew bundle --force-cleanup --file="$BREWFILE"
 else
     echo "🌀 No Brewfile found, skipping brew bundle"
 fi

--- a/README.md
+++ b/README.md
@@ -48,3 +48,13 @@ sh -c "$(curl -fsLS get.chezmoi.io)" -- -b $HOME/.local/bin init --source=~/ghq/
     - 軌跡の速さを一番早く
     - タップでクリック にチェック
 
+## Neovim ローカル開発プラグインのリンク作成
+
+`iwano.nvim` / `amanoukihashi.nvim` をローカルのリポジトリから読み込むため、下記のシンボリックリンクを作成する:
+
+```bash
+mkdir -p ~/.local/share/nvim/site/pack/mine/opt
+ln -s ~/ghq/github.com/0ta2/iwano.nvim ~/.local/share/nvim/site/pack/mine/opt/iwano.nvim-local
+ln -s ~/ghq/github.com/0ta2/amanoukihashi.nvim ~/.local/share/nvim/site/pack/mine/opt/amanoukihashi.nvim-local
+```
+

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -3,7 +3,6 @@
     "language": "japanese",
     "vim": true,
     "voiceEnabled": true,
-    "effortLevel": "high",
     "enabledPlugins": {
         "lua-lsp@claude-plugins-official": true,
         "gopls-lsp@claude-plugins-official": true,
@@ -41,16 +40,16 @@
             "Read(./.env)",
             "Read(./.env.*)",
             "Read(./secrets/**)",
-            "Bash(rm -rf:*)",
-            "Bash(sudo:*)",
-            "Bash(gh pr merge:*)",
-            "Bash(gh repo delete:*)"
+            "Bash(sudo:*)"
         ],
         "ask": [
             "Bash(git push:*)",
             "Bash(git merge:*)",
             "Bash(git rebase:*)"
         ]
+    },
+    "env": {
+        "CLAUDE_CODE_NO_FLICKER": "1"
     },
     "hooks": {
         "Stop": [

--- a/dot_config/nvim/plugin/60_ui.lua
+++ b/dot_config/nvim/plugin/60_ui.lua
@@ -224,10 +224,7 @@ vim.pack.add({
     { src = "https://github.com/Owen-Dechow/videre.nvim" },
 })
 
-require("videre").setup({
-    round_units = true,
-    simple_statusline = true,
-})
+require("videre").setup({})
 
 --
 -- ダッシュボード

--- a/dot_config/nvim/plugin/80_ai.lua
+++ b/dot_config/nvim/plugin/80_ai.lua
@@ -1,73 +1,72 @@
-vim.pack.add({
-    { src = "https://github.com/folke/sidekick.nvim" },
-})
-
-require("sidekick").setup({
-    cli = {
-        mux = {
-            backend = "tmux",
-            enabled = true,
-        },
-        win = {
-            layout = "right",
-            config = function(terminal)
-                local screen_width = vim.o.columns
-                if screen_width > 200 then
-                    terminal.opts.split = { width = 150, height = 0 }
-                else
-                    terminal.opts.split = { width = 80, height = 0 }
-                end
-            end,
-        },
-        prompts = {
-            changes = "変更内容をレビューしてください。",
-            diagnostics = "{file} の診断エラーを修正する方法を教えてください。\n{diagnostics}",
-            diagnostics_all = "以下の診断エラーを修正する方法を教えてください。\n{diagnostics_all}",
-            document = "{function|line} にドキュメントを追加してください。",
-            explain = "{this} を説明してください。",
-            fix = "{this} を修正してください。",
-            optimize = "{this} を最適化するにはどうすればよいですか？",
-            review = "{file} に問題や改善点がないかレビューしてください。",
-            tests = "{this} のテストを書いてください。",
-            buffers = "{buffers}",
-            file = "{file}",
-            line = "{line}",
-            position = "{position}",
-            quickfix = "{quickfix}",
-            selection = "{selection}",
-            ["function"] = "{function}",
-            class = "{class}",
-        },
-    },
-})
-
--- Keymaps
-vim.keymap.set({ "n" }, "<tab>", function()
-    if not require("sidekick").nes_jump_or_apply() then
-        return "<Tab>"
-    end
-end, { expr = true, desc = "Goto/Apply Next Edit Suggestion" })
-
-vim.keymap.set({ "n", "t", "i", "x" }, "<c-.>", function()
-    require("sidekick.cli").toggle({ filter = { installed = true } })
-end, { desc = "Sidekick Toggle" })
-
-vim.keymap.set("n", "<leader>ad", function()
-    require("sidekick.cli").close()
-end, { desc = "CLIのセッションを閉じる" })
-
-vim.keymap.set({ "x", "n" }, "<leader>at", function()
-    require("sidekick.cli").send({ msg = "{this}" })
-end, { desc = "現在のブロックを Sidekick に連携する" })
-
-vim.keymap.set("n", "<leader>af", function()
-    require("sidekick.cli").send({ msg = "{file}" })
-end, { desc = "現在のファイルを Sidekick に連携する" })
-
-vim.keymap.set("x", "<leader>av", function()
-    require("sidekick.cli").send({ msg = "{selection}" })
-end, { desc = "選択している範囲を Sidekick に連携する" })
-
-vim.keymap.set({ "n", "x" }, "<leader>ap", function()
-    require("sidekick.cli").prompt()
-end, { desc = "Sidekick の Prompt を選択" })
+-- vim.pack.add({
+--     { src = "https://github.com/folke/sidekick.nvim" },
+-- })
+--
+-- require("sidekick").setup({
+--     cli = {
+--         mux = {
+--             backend = "tmux",
+--             enabled = true,
+--         },
+--         win = {
+--             layout = "right",
+--             config = function(terminal)
+--                 local screen_width = vim.o.columns
+--                 if screen_width > 200 then
+--                     terminal.opts.split = { width = 150, height = 0 }
+--                 else
+--                     terminal.opts.split = { width = 80, height = 0 }
+--                 end
+--             end,
+--         },
+--         prompts = {
+--             changes = "変更内容をレビューしてください。",
+--             diagnostics = "{file} の診断エラーを修正する方法を教えてください。\n{diagnostics}",
+--             diagnostics_all = "以下の診断エラーを修正する方法を教えてください。\n{diagnostics_all}",
+--             document = "{function|line} にドキュメントを追加してください。",
+--             explain = "{this} を説明してください。",
+--             fix = "{this} を修正してください。",
+--             optimize = "{this} を最適化するにはどうすればよいですか？",
+--             review = "{file} に問題や改善点がないかレビューしてください。",
+--             tests = "{this} のテストを書いてください。",
+--             buffers = "{buffers}",
+--             file = "{file}",
+--             line = "{line}",
+--             position = "{position}",
+--             quickfix = "{quickfix}",
+--             selection = "{selection}",
+--             ["function"] = "{function}",
+--             class = "{class}",
+--         },
+--     },
+-- })
+--
+-- vim.keymap.set({ "n" }, "<tab>", function()
+--     if not require("sidekick").nes_jump_or_apply() then
+--         return "<Tab>"
+--     end
+-- end, { expr = true, desc = "Goto/Apply Next Edit Suggestion" })
+--
+-- vim.keymap.set({ "n", "t", "i", "x" }, "<c-.>", function()
+--     require("sidekick.cli").toggle({ filter = { installed = true } })
+-- end, { desc = "Sidekick Toggle" })
+--
+-- vim.keymap.set("n", "<leader>ad", function()
+--     require("sidekick.cli").close()
+-- end, { desc = "CLIのセッションを閉じる" })
+--
+-- vim.keymap.set({ "x", "n" }, "<leader>at", function()
+--     require("sidekick.cli").send({ msg = "{this}" })
+-- end, { desc = "現在のブロックを Sidekick に連携する" })
+--
+-- vim.keymap.set("n", "<leader>af", function()
+--     require("sidekick.cli").send({ msg = "{file}" })
+-- end, { desc = "現在のファイルを Sidekick に連携する" })
+--
+-- vim.keymap.set("x", "<leader>av", function()
+--     require("sidekick.cli").send({ msg = "{selection}" })
+-- end, { desc = "選択している範囲を Sidekick に連携する" })
+--
+-- vim.keymap.set({ "n", "x" }, "<leader>ap", function()
+--     require("sidekick.cli").prompt()
+-- end, { desc = "Sidekick の Prompt を選択" })

--- a/dot_config/nvim/plugin/99_dev.lua
+++ b/dot_config/nvim/plugin/99_dev.lua
@@ -1,10 +1,4 @@
-if vim.loop.os_get_passwd().username == "0ta2" then
-    vim.cmd.packadd("iwano.nvim-local")
-else
-    vim.pack.add({
-        "https://github.com/0ta2/iwano.nvim",
-    })
-end
+vim.cmd.packadd("iwano.nvim-local")
 
 require("iwano").setup({
     tools = {
@@ -15,20 +9,17 @@ vim.keymap.set("n", "<Leader>k", function()
     require("iwano").toggle("lazygit")
 end)
 
-if vim.loop.os_get_passwd().username == "0ta2" then
-    vim.cmd.packadd("amanoukihashi.nvim-local")
-else
-    vim.pack.add({
-        { src = "https://github.com/0ta2/amanoukihashi.nvim", version = "feat/phase0" },
-    })
-end
+vim.cmd.packadd("amanoukihashi.nvim-local")
 require("amanoukihashi").setup({
     default_cmd = { "claude" },
     layout = "split",
+    split = {
+        width = vim.o.columns > 200 and 150 or 80,
+    },
 })
-vim.keymap.set({ "n", "t" }, "<leader>ca", function()
-    require("amanoukihashi").toggle("main")
-end, { desc = "Claude Code: main セッション" })
-vim.keymap.set({ "n", "t" }, "<leader>cb", function()
-    require("amanoukihashi").toggle("feat")
-end, { desc = "Claude Code: feat セッション" })
+vim.keymap.set({ "n", "t", "i", "x" }, "<c-.>", function()
+    require("amanoukihashi").toggle()
+end, { desc = "Claude Code: セッションをトグル" })
+vim.keymap.set("n", "<leader>af", "<Cmd>AmanoukihashiInsert @{file}<CR>", { desc = "amanoukihashi: 現在ファイルのパスを挿入" })
+vim.keymap.set("v", "<leader>as", ":AmanoukihashiInsert {selection}<CR>", { desc = "amanoukihashi: ビジュアル選択テキストを挿入" })
+vim.keymap.set("n", "<leader>al", "<Cmd>AmanoukihashiList<CR>", { desc = "amanoukihashi: セッション一覧" })


### PR DESCRIPTION
## 変更内容

- amanoukihashi.nvim を統合し、Claude Code セッションのトグル・ファイルパス挿入・セッション一覧のキーマップを追加
- iwano.nvim / amanoukihashi.nvim を常にローカルパッケージから読み込むようにし、リンク作成手順を README に記載
- sidekick.nvim の設定をコメントアウトで無効化(amanoukihashi.nvim への移行に伴う)
- videre.nvim の廃止オプションを削除
- Claude Code settings.json の deny リストを簡略化し CLAUDE_CODE_NO_FLICKER を追加
- brew bundle のクリーンアップオプションを --force-cleanup に変更

## 変更の理由

sidekick.nvim から自作の amanoukihashi.nvim へ移行し、開発中のローカルパッケージを
即座に反映できるようにするため。

## テスト

- [ ] Neovim で amanoukihashi.nvim のキーマップ・トグル動作を確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)