### PR TITLE
perf(nvim): 未使用の組み込みプラグインを無効化する

### DIFF
--- a/dot_config/nvim/init.lua
+++ b/dot_config/nvim/init.lua
@@ -1,5 +1,28 @@
 vim.loader.enable()
 
+-- 起動時間短縮: 使っていない組み込みプラグインを無効化
+for _, plugin in ipairs({
+    "gzip",
+    "tar",
+    "tarPlugin",
+    "zip",
+    "zipPlugin",
+    "getscript",
+    "getscriptPlugin",
+    "vimball",
+    "vimballPlugin",
+    "2html_plugin",
+    "logipat",
+    "rrhelper",
+    "spellfile_plugin",
+    "netrw",
+    "netrwPlugin",
+    "netrwSettings",
+    "netrwFileHandlers",
+}) do
+    vim.g["loaded_" .. plugin] = 1
+end
+
 -- リーダーキーを `<space>` に設定
 -- 詳しくは、 `:help mapleader` を参照
 vim.g.mapleader = " "


### PR DESCRIPTION
## タスク

リマインダー #116: nvimの起動速度改善

## 変更内容

- `init.lua` に未使用の組み込みプラグイン (netrw, zip/tar 系, getscript, vimball, 2html, logipat, rrhelper, spellfile) を無効化する `vim.g.loaded_*` 設定を追加
- これらは canola.nvim 等で代替されているか、この設定内で一切参照されていないことを `grep` で確認済み (動作への影響なし)
- `vim.loader.enable()` は既に init.lua の先頭で有効化されている (元タスクのメモにあったもう一つの提案は対応済み)

## 計測結果 (`nvim --headless --startuptime`, 5回計測)

- 変更前: 定常状態で 139-150ms 程度
- 変更後: 定常状態で 140-153ms 程度
- → 今回の変更単体では計測誤差の範囲内で、明確な改善は確認できなかった

起動時間の内訳を見ると、最も時間を使っているのは `plugin/20_editor.lua`
(約39ms)、`plugin/70_tools.lua` (約31ms)、`plugin/60_ui.lua` (約23ms) など
`plugin/*.lua` の eager loading で、ここを vim.pack の遅延読み込み
(`vim.pack.add({..., load = false})` + イベント/コマンドでの `require`) に
切り替えるのが次の改善ステップになりそう。ただし対象プラグインの選定や
ロードタイミングの設計判断が必要なため、今回は見送り、別タスクとして
切り出すのがよさそう。

## 朝の確認チェックリスト

- [ ] netrw / zip 等を無効化しても普段の操作に問題がないか (該当機能をそもそも使っていないはずだが確認)
- [ ] mergeしてchezmoi applyしたあと、nvim起動に問題がないか確認