### PR TITLE
feat(tmux): アクティブなペインの境界線を強調する

### DIFF
--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -37,6 +37,10 @@ set-window-option -g pane-base-index 1
 # paneのインデックス番号を自動的にナンバリングする
 set-option -g renumber-windows on
 
+# アクティブなペインの境界線を強調する (catppuccin mocha: blue / surface0)
+set-option -g pane-border-style "fg=#313244"
+set-option -g pane-active-border-style "fg=#89b4fa"
+
 # 新規ペインを作成する
 bind c new-window -c "#{pane_current_path}"
 # Prefix + | で縦に分割


### PR DESCRIPTION
## タスク

リマインダー #300: Tmuxがどのペインを選択しているかがわかりずらい

## 変更内容

`pane-border-style` / `pane-active-border-style` を設定し、アクティブなペインの境界線を
catppuccin mocha の青 (`#89b4fa`) で強調表示するようにした。非アクティブなペインの境界線は
既存ステータスラインで使われている surface0 (`#313244`) に揃えた。

## 朝の確認チェックリスト

- [ ] tmux でペインを複数分割し、アクティブなペインの境界線が青くハイライトされることを確認する
- [ ] ステータスラインの配色と違和感がないか確認する