### PR TITLE
feat(nvim): fzf-lua で隠しファイルを検索対象にする

### DIFF
--- a/dot_config/nvim/plugin/20_editor.lua
+++ b/dot_config/nvim/plugin/20_editor.lua
@@ -58,6 +58,9 @@ vim.pack.add({
 
 local fzf = require("fzf-lua")
 fzf.setup({
+    files = {
+        hidden = true,
+    },
     lsp = {
         jump1 = true,
         ignore_current_line = true,


### PR DESCRIPTION
## タスク

リマインダー #459: Fzf.nvimが隠しファイルの検索が対象にならないかも

## 変更内容

`fzf.setup()` の `files` セクションに `hidden = true` を明示的に追加した。

fzf-lua のデフォルトは既に `hidden = true` だが、設定に明記することで:
- 意図を明確にする
- 将来の fzf-lua バージョン変更でデフォルトが変わった場合でも挙動が保たれる

この設定により `<C-p>` (FzfLua global) や `<C-p>` (canola 内のファイル検索) で
`.gitconfig` や `.zshrc` などのドットファイルが検索対象になる。

## 朝の確認チェックリスト

- [ ] `<C-p>` で `.zshrc` や `.gitconfig` などの隠しファイルが表示されることを確認
- [ ] `<A-h>` で隠しファイルの表示/非表示トグルが動作することを確認