### PR TITLE
feat(nvim): fzf-lua で gitignore 対象ファイルも検索対象にする

### DIFF
--- a/dot_config/nvim/plugin/20_editor.lua
+++ b/dot_config/nvim/plugin/20_editor.lua
@@ -60,6 +60,7 @@ local fzf = require("fzf-lua")
 fzf.setup({
     files = {
         hidden = true,
+        no_ignore = true,
     },
     lsp = {
         jump1 = true,


### PR DESCRIPTION
## 背景

#73 で `hidden = true` を入れて隠しファイル(ドットファイル)を検索対象にしたが、
gitignore で除外されたファイルは依然として検索に出てこなかった。

`hidden`(ドットファイルの表示)と gitignore の尊重は独立した設定で、
gitignore 対象を出すには別途 `no_ignore` が必要。

## 変更内容

`fzf.setup()` の `files` セクションに `no_ignore = true` を追加した。

fd / rg に `--no-ignore` フラグが渡り、`.gitignore` / `.ignore` で
除外されているファイルも `<C-p>`(ファイル検索)の対象になる。

`.git/` 配下は fzf-lua のデフォルト(`fd_opts` の `--exclude .git`、
`rg_opts` の `-g "!.git"`)で引き続き除外される。

## 朝の確認チェックリスト

- [ ] `<C-p>` で gitignore された生成物(例: `node_modules/`, ビルド成果物)が表示されることを確認
- [ ] `.git/` 配下のファイルが検索結果に出てこないことを確認
- [ ] `<A-i>` (toggle_ignore) でトグルが動作することを確認