### PR TITLE
feat(nvim): lsplinks.nvim を追加し gd にドキュメントリンクのフォールバックを実装

### DIFF
--- a/dot_config/nvim/plugin/40_lsp.lua
+++ b/dot_config/nvim/plugin/40_lsp.lua
@@ -3,12 +3,14 @@
 --
 vim.pack.add({
     { src = "https://github.com/folke/lazydev.nvim" },
+    { src = "https://github.com/icholy/lsplinks.nvim" },
 })
 require("lazydev").setup({
     library = {
         { path = "${3rd}/luv/library", words = { "vim%.uv" } },
     },
 })
+require("lsplinks").setup()
 
 --
 -- Mason（LSP/ツールインストーラ）
@@ -78,12 +80,14 @@ vim.api.nvim_create_autocmd("LspAttach", {
         )
         vim.keymap.set("n", "gk", vim.lsp.buf.hover, vim.tbl_extend("force", opts, { desc = "ホバー" }))
         vim.keymap.set("n", "gR", vim.lsp.buf.rename, vim.tbl_extend("force", opts, { desc = "リネーム" }))
-        vim.keymap.set(
-            "n",
-            "gd",
-            "<Cmd>FzfLua lsp_definitions<CR>",
-            vim.tbl_extend("force", opts, { desc = "定義へ移動" })
-        )
+        vim.keymap.set("n", "gd", function()
+            -- LSP ドキュメントリンク（$ref 等）があれば開き、なければ定義へ移動
+            if require("lsplinks").current() then
+                require("lsplinks").open()
+            else
+                vim.cmd("FzfLua lsp_definitions")
+            end
+        end, vim.tbl_extend("force", opts, { desc = "定義/ドキュメントリンクへ移動" }))
         vim.keymap.set(
             "n",
             "gD",


### PR DESCRIPTION
## タスク

リマインダー #117: icholy/lsplinks.nvim を検討

## 変更内容

[icholy/lsplinks.nvim](https://github.com/icholy/lsplinks.nvim) を追加。

LSP の `documentLink` 機能（OpenAPI の `$ref` 参照や Go の import リンク等）を `gd` で開けるようにし、ドキュメントリンクがない場合は従来通り `FzfLua lsp_definitions` にフォールバックする。

### 実装方針

- `lsplinks.current()` でカーソル位置にドキュメントリンクがあるか判定
- ある場合 → `lsplinks.open()` でリンクを開く（`file://` は Neovim 内、`https://` はブラウザ）
- ない場合 → 既存の `FzfLua lsp_definitions` にフォールバック

## 朝の確認チェックリスト

- [x] `:checkhealth` でエラーなし
- [x] OpenAPI/Swagger ファイルで `$ref` の上で `gd` → ファイル内定義にジャンプする
- [x] 通常の Lua/Go ファイルで `gd` → FzfLua が開く（従来通り）
- [x] Go の import 文で `gd` → pkg.go.dev がブラウザで開く（LSP サーバーが対応している場合）