### PR TITLE
feat(tmux): flash-copy.tmux を追加する

### DIFF
--- a/.chezmoiexternal.toml
+++ b/.chezmoiexternal.toml
@@ -18,3 +18,7 @@
     type = "git-repo"
     url = "https://github.com/eduwass/tmux-palette.git"
     refreshPeriod = "168h"
+[".config/tmux/plugins/Kristijan/flash-copy.tmux"]
+    type = "git-repo"
+    url = "https://github.com/Kristijan/flash-copy.tmux.git"
+    refreshPeriod = "168h"

--- a/dot_config/tmux/tmux.conf
+++ b/dot_config/tmux/tmux.conf
@@ -168,3 +168,6 @@ set -g @smart-splits_resize_step_size '3' # change the step-size for resizing.
 # Load tmux-palette
 set -g @palette-key 'off'
 bind-key f run-shell "~/.config/tmux/plugins/eduwass/tmux-palette/bin/tmux-palette.sh"
+
+# flash-copy: pane 内の単語を flash.nvim 風ラベルでコピー (Prefix + F)
+run-shell ~/.config/tmux/plugins/Kristijan/flash-copy.tmux/tmux-flash-copy.tmux


### PR DESCRIPTION
## タスク

リマインダー #78: tmuxでflash.nvimみたいにするプラグイン

## 変更内容

[Kristijan/flash-copy.tmux](https://github.com/Kristijan/flash-copy.tmux) を追加。

pane 内の表示単語をリアルタイム検索し、flash.nvim 風のラベルキーで選択してクリップボードにコピーできるプラグイン。

- `.chezmoiexternal.toml` に `git-repo` エントリを追加
- `tmux.conf` に `run-shell` で読み込みを追加

**キーバインド**: `<prefix> F`（Shift+f）でフラッシュコピーモード起動

**依存**: Python 3.9+（tmux は 3.2+）

## 朝の確認チェックリスト

- [x] `chezmoi apply` 後に `~/.config/tmux/plugins/Kristijan/flash-copy.tmux/` が存在する
- [x] `tmux source ~/.config/tmux/tmux.conf` でエラーなし
- [x] `<prefix> F` を押すとコピーモードが起動する
- [x] 単語を入力してラベルが表示され、ラベルキーでコピーできる