### PR TITLE
feat(claude): statusline に effort レベルを表示する

### DIFF
--- a/dot_claude/executable_statusline.py
+++ b/dot_claude/executable_statusline.py
@@ -43,6 +43,14 @@ def fmt(label, pct, resets_at=None):
 model = data.get('model', {}).get('display_name', 'Claude')
 parts = [model]
 
+effort_level = data.get('effort', {}).get('level')
+if effort_level is not None:
+    thinking = data.get('thinking', {}).get('enabled', False)
+    label = f'effort:{effort_level}'
+    if thinking:
+        label += '+think'
+    parts.append(label)
+
 ctx = data.get('context_window', {}).get('used_percentage')
 if ctx is not None:
     parts.append(fmt('ctx', ctx))


### PR DESCRIPTION
## タスク

リマインダー #480: Claude Code ステータスラインに effort 表示を追加

## 変更内容

`~/.claude/statusline.py` に effort レベルの表示を追加した。

- `effort.level` フィールドが存在する場合、モデル名の直後に `effort:{level}` を表示する
- `thinking.enabled` が true の場合は `effort:{level}+think` と表示する
- 古いバージョンの Claude Code (フィールドなし) との後方互換を保つ

表示例:
```
 Sonnet 4.6 │ effort:high │ ctx ██████ 45% │ 5h ███░░░ 23% 4h30m │ 7d █░░░░░ 12% 3d20h
 Opus 4.8 │ effort:xhigh+think │ ctx ▌░░░░░ 10%
```

## 朝の確認チェックリスト

- [ ] `chezmoi apply` 後に Claude Code のステータスラインで effort が表示されることを確認する
- [ ] `/effort` で変更したとき表示が即時更新されることを確認する
- [ ] effort フィールドのない環境 (古い Claude Code) でエラーが出ないことを確認する