### PR TITLE
feat(claude): statusline の 5h/7d に予測着地を表示する（7d は平日のみ）

### DIFF
--- a/dot_claude/executable_statusline.py
+++ b/dot_claude/executable_statusline.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import json, sys, time
+from datetime import date, timedelta
 
 data = json.load(sys.stdin)
 
@@ -35,14 +36,32 @@ def remaining(resets_at):
         return f'{d}d{h}h'
     return f'{h}h{m:02d}m'
 
-def calc_projected(pct, resets_at, window_secs):
+def count_weekdays(start_ts, end_ts):
+    d, end_d = date.fromtimestamp(start_ts), date.fromtimestamp(end_ts)
+    count = 0
+    while d < end_d:
+        if d.weekday() < 5:
+            count += 1
+        d += timedelta(days=1)
+    return count
+
+def calc_projected(pct, resets_at, window_secs, weekdays_only=False):
     """このペースが続いた場合のリセット時点の予測着地 (%)。窓の開始直後は None。"""
     if resets_at is None:
         return None
-    elapsed = window_secs - max(0, resets_at - time.time())
-    if elapsed < 60:
-        return None
-    return pct * window_secs / elapsed
+    now = time.time()
+    if weekdays_only:
+        start_ts = resets_at - window_secs
+        elapsed = count_weekdays(start_ts, now)
+        total = count_weekdays(start_ts, resets_at)
+        if elapsed < 1 or total == 0:
+            return None
+        return pct * total / elapsed
+    else:
+        elapsed = window_secs - max(0, resets_at - now)
+        if elapsed < 60:
+            return None
+        return pct * window_secs / elapsed
 
 def fmt(label, pct, resets_at=None, projected=None):
     p = round(pct)
@@ -69,7 +88,7 @@ if five is not None:
 week_data = data.get('rate_limits', {}).get('seven_day', {})
 week = week_data.get('used_percentage')
 if week is not None:
-    week_proj = calc_projected(week, week_data.get('resets_at'), 7 * 86400)
+    week_proj = calc_projected(week, week_data.get('resets_at'), 7 * 86400, weekdays_only=True)
     parts.append(fmt('7d', week, week_data.get('resets_at'), projected=week_proj))
 
 print(f'{DIM}│{R}'.join(f' {p} ' for p in parts), end='')

--- a/dot_claude/executable_statusline.py
+++ b/dot_claude/executable_statusline.py
@@ -36,14 +36,18 @@ def remaining(resets_at):
         return f'{d}d{h}h'
     return f'{h}h{m:02d}m'
 
-def count_weekdays(start_ts, end_ts):
-    d, end_d = date.fromtimestamp(start_ts), date.fromtimestamp(end_ts)
-    count = 0
+def count_weekdays_split(start_ts, pivot_ts, end_ts):
+    """start→pivot を elapsed、start→end を total として平日数を同時計算する。"""
+    d = date.fromtimestamp(start_ts)
+    pivot_d, end_d = date.fromtimestamp(pivot_ts), date.fromtimestamp(end_ts)
+    elapsed = total = 0
     while d < end_d:
         if d.weekday() < 5:
-            count += 1
+            total += 1
+            if d < pivot_d:
+                elapsed += 1
         d += timedelta(days=1)
-    return count
+    return elapsed, total
 
 def calc_projected(pct, resets_at, window_secs, weekdays_only=False):
     """このペースが続いた場合のリセット時点の予測着地 (%)。窓の開始直後は None。"""
@@ -52,9 +56,8 @@ def calc_projected(pct, resets_at, window_secs, weekdays_only=False):
     now = time.time()
     if weekdays_only:
         start_ts = resets_at - window_secs
-        elapsed = count_weekdays(start_ts, now)
-        total = count_weekdays(start_ts, resets_at)
-        if elapsed < 1 or total == 0:
+        elapsed, total = count_weekdays_split(start_ts, now, resets_at)
+        if elapsed < 1 or total == 0:  # elapsed は日数単位
             return None
         return pct * total / elapsed
     else:


### PR DESCRIPTION
## タスク

リマインダー #456 の追加改善（PR #81 の続き）

## 変更内容

**消費ペース (`xx.x%/h`) → 予測着地 (`→ ~xx%`) に変更**

- ペースの数字は「多いか少ないか」の判断に一手間必要だった
- リセット時にどこで着地するかを直接表示することで直感的に判断できる
- `calc_projected(pct, resets_at, window_secs, weekdays_only)` に統一

**7d の予測着地は平日のみで計算**

- 週末は使わない前提で、月〜金の 5 平日ペースで換算
- 7 日間に含まれる平日は常に 5 日なので `used_pct × 5 / elapsed_weekdays`
- 土日に使い始めた直後は `elapsed_weekdays=0` のため非表示（除算ガード）

**表示例:**
```
Claude Sonnet 4.6 │ ctx ██░░░░ 35% │ 5h ██▌░░░ 42% 0h59m → ~52% │ 7d █░░░░░ 20% 4d23h → ~50%
```

## 朝の確認チェックリスト

- [ ] Claude Code を起動して `→ ~xx%` が表示されることを確認
- [ ] 月〜金に使って 7d の予測着地が平日ペースで計算されることを確認
- [ ] `resets_at` が `null` のとき予測着地が非表示であることを確認