### PR TITLE
試す(nvim): jira.nvim を追加する

### DIFF
--- a/dot_config/nvim/plugin/70_tools.lua
+++ b/dot_config/nvim/plugin/70_tools.lua
@@ -100,3 +100,19 @@ require("iwe").setup({
     },
 })
 vim.keymap.set("n", "gf", "<Plug>(iwe-picker-find-files)")
+
+--
+-- Jira クライアント（jira.nvim）
+-- 初回: :Jira auth login で認証する
+--
+vim.pack.add({
+    "https://github.com/letieu/jira.nvim",
+})
+
+require("jira").setup({
+    jira = {
+        limit = 200,
+    },
+})
+
+vim.keymap.set("n", "<leader>jj", "<Cmd>Jira<CR>", { desc = "Jira: ダッシュボードを開く" })


### PR DESCRIPTION
## タスク

リマインダー #118: letieu/jira.nvim: I got tired of opening my browser for Jira

## 変更内容

`dot_config/nvim/plugin/70_tools.lua` に jira.nvim を追加。

- `vim.pack.add` でプラグインを登録
- `<leader>jj` でダッシュボードを開くキーマップを設定

認証情報はファイルに持たず、初回のみ `:Jira auth login` で対話的にセットアップする（Atlassian APIトークンを要求）。

## 朝の確認チェックリスト

- [ ] `:Jira auth login` を実行し、Jira URLと APIトークンを入力して認証
- [ ] `<leader>jj` でダッシュボードが開くことを確認
- [ ] `:Jira <PROJECT_KEY>` でプロジェクト別ビューが開くことを確認

> [!NOTE]
> jira.nvim はまだ early development。破壊的変更の可能性あり。