### PR TITLE
feat(zsh): tmux-rename-project 関数を追加

### DIFF
--- a/dot_config/zsh/functions/executable_tmux_rename_project.zsh
+++ b/dot_config/zsh/functions/executable_tmux_rename_project.zsh
@@ -1,0 +1,7 @@
+function tmux-rename-project() {
+  [[ -z "$TMUX" ]] && { echo "not in tmux" >&2; return 1 }
+  local raw
+  raw=$(~/.local/bin/tmux-window-name "$PWD")
+  local name="${${(L)raw}//[^A-Za-z0-9_.-]/-}"
+  tmux rename-session -- "$name"
+}


### PR DESCRIPTION
## タスク

リマインダー #314: tmux-rename-project便利そう

## 変更内容

`tmux-rename-project` zsh 関数を追加。
現在のディレクトリ（git プロジェクト or ディレクトリ名）を取得して
tmux セッション名にリネームする。

- 既存の `~/.local/bin/tmux-window-name` スクリプトでプロジェクト名を取得
- `ta` コマンドと同じ正規化ルール（小文字化・英数._- 以外は `-` に変換）を適用
- tmux 外では `not in tmux` を出力して return 1

## 朝の確認チェックリスト

- [ ] ghq プロジェクトディレクトリで `tmux-rename-project` を実行し、セッション名が変わることを確認
- [ ] git ディレクトリ外のディレクトリで実行し、ディレクトリ名がセッション名になることを確認
- [ ] tmux 外（通常ターミナル）で実行し、エラーメッセージが出ることを確認