### PR TITLE
feat(nvim): meow.yarn.nvim で LSP 階層ビューを追加

### DIFF
--- a/dot_config/nvim/plugin/40_lsp.lua
+++ b/dot_config/nvim/plugin/40_lsp.lua
@@ -66,6 +66,26 @@ if _ok then
 end
 
 --
+-- LSP 階層ビューア（meow.yarn.nvim）
+--
+vim.pack.add({
+    { src = "https://github.com/retran/meow.yarn.nvim" },
+})
+require("meow.yarn").setup({})
+vim.keymap.set("n", "<leader>yt", function()
+    require("meow.yarn").open_tree("type_hierarchy", "supertypes")
+end, { desc = "型階層（上位型）" })
+vim.keymap.set("n", "<leader>yT", function()
+    require("meow.yarn").open_tree("type_hierarchy", "subtypes")
+end, { desc = "型階層（下位型）" })
+vim.keymap.set("n", "<leader>yc", function()
+    require("meow.yarn").open_tree("call_hierarchy", "callers")
+end, { desc = "呼び出し元一覧" })
+vim.keymap.set("n", "<leader>yC", function()
+    require("meow.yarn").open_tree("call_hierarchy", "callees")
+end, { desc = "呼び出し先一覧" })
+
+--
 -- LSP キーマップ
 --
 vim.api.nvim_create_autocmd("LspAttach", {


### PR DESCRIPTION
## タスク

リマインダー #363: GitHub - retran/meow.yarn.nvim: A purr-fectly simple way to visualize LSP hierarchies in Neovim.

## 変更内容

`dot_config/nvim/plugin/40_lsp.lua` に meow.yarn.nvim を追加。

- `vim.pack.add` でプラグイン追加（依存の nui.nvim は `11_dependency.lua` に既存）
- デフォルト設定で `require("meow.yarn").setup({})` 呼び出し
- キーマップ: `<leader>yt/yT/yc/yC` で型階層・呼び出し階層を表示

| キー | 機能 |
|------|------|
| `<leader>yt` | 型階層（上位型 / supertypes） |
| `<leader>yT` | 型階層（下位型 / subtypes） |
| `<leader>yc` | 呼び出し元一覧（callers） |
| `<leader>yC` | 呼び出し先一覧（callees） |

## 朝の確認チェックリスト

- [x] Neovim 起動時にエラーが出ないこと（`:PackUpdate` で meow.yarn.nvim がインストールされること）
- [x] LSP が有効なバッファで `<leader>yc` を押すと階層ビューが開くこと
- [x] 階層ビュー内で `<CR>` でジャンプ、`q` で閉じられること
- [x] 気に入らなければ PR をクローズするだけで OK（設定は最小限のデフォルトのみ）