### PR TITLE
feat(nvim): code-bridge.nvim を試験導入する

### DIFF
--- a/dot_config/nvim/plugin/80_ai.lua
+++ b/dot_config/nvim/plugin/80_ai.lua
@@ -70,3 +70,25 @@
 -- vim.keymap.set({ "n", "x" }, "<leader>ap", function()
 --     require("sidekick.cli").prompt()
 -- end, { desc = "Sidekick の Prompt を選択" })
+
+--
+-- code-bridge.nvim — tmux で動く外部 Claude Code セッションへのコンテキスト送信
+--
+vim.pack.add({
+    { src = "https://github.com/samir-roy/code-bridge.nvim" },
+})
+
+require("code-bridge").setup({
+    tmux = {
+        target_mode = "window_name",
+        window_name = "claude",
+        switch_to_target = true,
+        find_node_process = true, -- Claude Code は node.js プロセスで動作する
+    },
+})
+
+vim.keymap.set({ "n", "v" }, "<leader>cb", ":CodeBridgeTmux<CR>", { desc = "code-bridge: ファイルを Claude に送信" })
+vim.keymap.set({ "n", "v" }, "<leader>ci", ":CodeBridgeTmuxInteractive<CR>", { desc = "code-bridge: インタラクティブ送信" })
+vim.keymap.set("n", "<leader>cd", ":CodeBridgeTmuxDiff<CR>", { desc = "code-bridge: git diff を送信" })
+vim.keymap.set({ "n", "v" }, "<leader>cq", ":CodeBridgeQuery<CR>", { desc = "code-bridge: クイックチャット" })
+vim.keymap.set("n", "<leader>cc", ":CodeBridgeChat<CR>", { desc = "code-bridge: チャットを開く" })


### PR DESCRIPTION
## タスク

リマインダー #418: samir-roy/code-bridge.nvim を試す

## 変更内容

`80_ai.lua` に `code-bridge.nvim` を追加した。

- tmux 上で動く外部 Claude Code セッション（ウィンドウ名 `claude`）へ、ファイルコンテキストを送信できる
- `amanoukihashi.nvim`（Neovim 内でターミナルを起動）と役割が異なり、別ターミナルで動く Claude Code と連携したいときに使う
- `find_node_process = true` で Claude Code の node.js プロセスを正しく検出する

### キーマップ

| キー | コマンド | 説明 |
|------|----------|------|
| `<leader>cb` | `:CodeBridgeTmux` | 現在ファイル/選択範囲を Claude に送信 |
| `<leader>ci` | `:CodeBridgeTmuxInteractive` | 送信前にプロンプトを編集 |
| `<leader>cd` | `:CodeBridgeTmuxDiff` | git diff (unstaged) を送信 |
| `<leader>cq` | `:CodeBridgeQuery` | クイックチャット（バッファ内） |
| `<leader>cc` | `:CodeBridgeChat` | チャットバッファを開く |

## 朝の確認チェックリスト

- [ ] tmux ウィンドウ名 `claude` で Claude Code を起動し、`<leader>cb` でファイルが送信されることを確認
- [ ] `<leader>ci` でインタラクティブプロンプトが開くことを確認
- [ ] `<leader>cd` で git diff が送信されることを確認
- [ ] `<leader>cq` でクイックチャットバッファが開くことを確認
- [ ] `amanoukihashi.nvim` の `<leader>a` 系キーマップと競合していないことを確認